### PR TITLE
Fix meta provides via Dist::Zilla config

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,5 +33,6 @@ tag_format = %v
 directory = t
 directory = inc
 
+[MetaProvides::Package]
 
 


### PR DESCRIPTION
Tweak Dist::Zilla config to add a provides stanza to dist.ini

Fix the warning from Kwalitee about "meta yml has provides", by
adding the necessary config to dist.ini to generate the list of modules
provided using the Dist::Zilla::Plugin::MetaProvides plugin.
