### PR TITLE
Switch to moo

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Path-Dispatcher
 
+1.07 2015-02-25
+        Switch from Any::Moose (Now deprecated) to Moo (David Pottage)
+            https://github.com/sartak/path-dispatcher/pull/3
+
 1.06 2015-02-18
         Switch packaging system to Dist::Zilla (David Pottage)
             https://github.com/sartak/path-dispatcher/pull/1

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name = Path-Dispatcher
-version = 1.06
+version = 1.07
 author = Shawn M Moore, C<< <sartak at bestpractical.com> >>
 license = Perl_5
 copyright_holder = Shawn M Moore

--- a/lib/Path/Dispatcher.pm
+++ b/lib/Path/Dispatcher.pm
@@ -1,5 +1,5 @@
 package Path::Dispatcher;
-use Any::Moose;
+use Moo;
 use 5.008001;
 
 # VERSION
@@ -10,6 +10,7 @@ use Path::Dispatcher::Path;
 
 use constant dispatch_class => 'Path::Dispatcher::Dispatch';
 use constant path_class     => 'Path::Dispatcher::Path';
+use Scalar::Util 'blessed';
 
 with 'Path::Dispatcher::Role::Rules';
 
@@ -72,7 +73,7 @@ sub _autobox_path {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Dispatch.pm
+++ b/lib/Path/Dispatcher/Dispatch.pm
@@ -1,12 +1,13 @@
 package Path::Dispatcher::Dispatch;
-use Any::Moose;
+use Carp;
+use Moo;
 use Try::Tiny;
 
 use Path::Dispatcher::Match;
 
 has _matches => (
     is        => 'ro',
-    isa       => 'ArrayRef',
+    isa       => sub { die "not an ArrayRef" unless 'ARRAY' eq ref $_[0] },
     default   => sub { [] },
 );
 
@@ -61,7 +62,7 @@ sub run {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Match.pm
+++ b/lib/Path/Dispatcher/Match.pm
@@ -1,42 +1,49 @@
 package Path::Dispatcher::Match;
-use Any::Moose;
-
+use Moo;
 use Path::Dispatcher::Path;
 use Path::Dispatcher::Rule;
 
 has path => (
     is       => 'ro',
-    isa      => 'Path::Dispatcher::Path',
+    isa      => sub { die "$_[0] not isa Path::Dispatcher::Path" unless $_[0]->isa('Path::Dispatcher::Path') },
     required => 1,
 );
 
 has leftover => (
     is  => 'ro',
-    isa => 'Str',
+    isa => sub { die "$_[0] is not a String" unless( defined $_[0] && '' eq ref $_[0] ) },
 );
 
 has rule => (
     is       => 'ro',
-    isa      => 'Path::Dispatcher::Rule',
+    isa      => sub { die "$_[0] not isa Path::Dispatcher::Rule" unless $_[0]->isa('Path::Dispatcher::Rule') },
     required => 1,
     handles  => ['payload'],
 );
 
 has positional_captures => (
     is      => 'ro',
-    isa     => 'ArrayRef[Str|Undef]',
+    isa     => sub { die "$_[0] is not an ArrayRef" unless 'ARRAY' eq ref $_[0] },
     default => sub { [] },
 );
 
 has named_captures => (
     is      => 'ro',
-    isa     => 'HashRef[Str|Undef]',
+    isa     => sub {
+        die "$_[0] is not a HashRef" unless 'HASH' eq ref $_[0];
+
+        foreach my $value ( values %{$_[0]} ) {
+            next unless defined $value;  # undef is allowed
+            die "Not a String"
+                if ref $value;
+        }
+    },
     default => sub { {} },
 );
 
 has parent => (
     is        => 'ro',
-    isa       => 'Path::Dispatcher::Match',
+    isa      => sub { die "$_[0] not isa Path::Dispatcher::Match" unless $_[0]->isa('Path::Dispatcher::Match') },
     predicate => 'has_parent',
 );
 
@@ -65,7 +72,7 @@ sub named {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Path.pm
+++ b/lib/Path/Dispatcher/Path.pm
@@ -1,29 +1,30 @@
 package Path::Dispatcher::Path;
-use Any::Moose;
+use Moo;
 
 use overload q{""} => sub { shift->path };
 
 has path => (
     is        => 'ro',
-    isa       => 'Str',
+    isa       => sub { die "$_[0] is not a String" unless( defined $_[0] && '' eq ref $_[0] ) },
     predicate => 'has_path',
 );
 
 has metadata => (
     is        => 'ro',
-    isa       => 'HashRef',
+    isa       => sub { die "not an ArrayRef" unless 'HASH' eq ref $_[0] },
     predicate => 'has_metadata',
 );
 
 # allow Path::Dispatcher::Path->new($path)
-sub BUILDARGS {
+around BUILDARGS => sub {
+    my $orig = shift;
     my $self = shift;
 
     if (@_ == 1 && !ref($_[0])) {
         unshift @_, 'path';
     }
 
-    $self->SUPER::BUILDARGS(@_);
+    $self->$orig(@_);
 };
 
 sub clone_path {
@@ -41,7 +42,7 @@ sub get_metadata {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Role/Rules.pm
+++ b/lib/Path/Dispatcher/Role/Rules.pm
@@ -1,9 +1,10 @@
 package Path::Dispatcher::Role::Rules;
-use Any::Moose '::Role';
+use Carp;
+use Moo::Role;
 
 has _rules => (
     is       => 'ro',
-    isa      => 'ArrayRef',
+    isa      => sub { die "not an ArrayRef" unless 'ARRAY' eq ref $_[0] },
     init_arg => 'rules',
     default  => sub { [] },
 );
@@ -30,7 +31,7 @@ sub unshift_rule {
 
 sub rules { @{ shift->{_rules} } }
 
-no Any::Moose;
+no Moo::Role;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule.pm
+++ b/lib/Path/Dispatcher/Rule.pm
@@ -1,5 +1,5 @@
 package Path::Dispatcher::Rule;
-use Any::Moose;
+use Moo;
 
 use Path::Dispatcher::Match;
 
@@ -12,16 +12,17 @@ has payload => (
 
 has prefix => (
     is      => 'ro',
-    isa     => 'Bool',
+    isa     => sub { die "$_[0] is not Bool" unless( ( $_[0] == !!$_[0] ) or ( 0 == $_[0] ) ) },
     default => 0,
 );
 
 # support for deprecated "block" attribute
 sub block { shift->payload(@_) }
 sub has_block { shift->has_payload(@_) }
-override BUILDARGS => sub {
+around BUILDARGS => sub {
+    my $orig = shift;
     my $self = shift;
-    my $args = super;
+    my $args = $self->$orig(@_);
     $args->{payload} ||= delete $args->{block};
     return $args;
 };
@@ -77,7 +78,7 @@ sub run {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 # don't require others to load our subclasses explicitly
 require Path::Dispatcher::Rule::Alternation;

--- a/lib/Path/Dispatcher/Rule/Alternation.pm
+++ b/lib/Path/Dispatcher/Rule/Alternation.pm
@@ -1,5 +1,5 @@
 package Path::Dispatcher::Rule::Alternation;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 with 'Path::Dispatcher::Role::Rules';
@@ -25,7 +25,7 @@ sub complete {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Always.pm
+++ b/lib/Path/Dispatcher/Rule/Always.pm
@@ -1,5 +1,5 @@
 package Path::Dispatcher::Rule::Always;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 sub _match {
@@ -12,7 +12,7 @@ sub _match {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Chain.pm
+++ b/lib/Path/Dispatcher/Rule/Chain.pm
@@ -1,10 +1,11 @@
 package Path::Dispatcher::Rule::Chain;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule::Always';
 
-override payload => sub {
+around payload => sub {
+    my $orig    = shift;
     my $self    = shift;
-    my $payload = super;
+    my $payload = $self->$orig(@_);
 
     if (!@_) {
         return sub {
@@ -17,7 +18,7 @@ override payload => sub {
 };
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/CodeRef.pm
+++ b/lib/Path/Dispatcher/Rule/CodeRef.pm
@@ -1,10 +1,10 @@
 package Path::Dispatcher::Rule::CodeRef;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 has matcher => (
     is       => 'ro',
-    isa      => 'CodeRef',
+    isa      => sub { die "not a CodeRef" unless 'CODE' eq ref $_[0] },
     required => 1,
 );
 
@@ -17,7 +17,7 @@ sub _match {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Dispatch.pm
+++ b/lib/Path/Dispatcher/Rule/Dispatch.pm
@@ -1,10 +1,10 @@
 package Path::Dispatcher::Rule::Dispatch;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 has dispatcher => (
     is       => 'ro',
-    isa      => 'Path::Dispatcher',
+    isa      => sub { die "$_[0] not isa Path::Dispatcher" unless $_[0]->isa('Path::Dispatcher') },
     required => 1,
     handles  => ['rules', 'complete'],
 );
@@ -18,7 +18,7 @@ sub match {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Empty.pm
+++ b/lib/Path/Dispatcher/Rule/Empty.pm
@@ -1,5 +1,5 @@
 package Path::Dispatcher::Rule::Empty;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 sub _match {
@@ -10,7 +10,7 @@ sub _match {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Enum.pm
+++ b/lib/Path/Dispatcher/Rule/Enum.pm
@@ -1,16 +1,17 @@
 package Path::Dispatcher::Rule::Enum;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 has enum => (
     is       => 'ro',
-    isa      => 'ArrayRef[Str]',
+    isa      => sub { die "not an ArrayRef" unless 'ARRAY' eq ref $_[0] },
     required => 1,
 );
 
+# '' or 0 will be accepted for false, 1 for true.
 has case_sensitive => (
     is      => 'ro',
-    isa     => 'Bool',
+    isa     => sub { die "$_[0] is not Bool" unless( ( $_[0] == !!$_[0] ) or ( 0 == $_[0] ) ) },
     default => 1,
 );
 
@@ -86,7 +87,7 @@ sub complete {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Eq.pm
+++ b/lib/Path/Dispatcher/Rule/Eq.pm
@@ -1,16 +1,18 @@
 package Path::Dispatcher::Rule::Eq;
-use Any::Moose;
+use Moo;
+
 extends 'Path::Dispatcher::Rule';
 
 has string => (
     is       => 'ro',
-    isa      => 'Str',
+    isa      => sub { die "$_[0] is not a String" unless( defined $_[0] && '' eq ref $_[0] ) },
     required => 1,
 );
 
+# '' or 0 will be accepted for false, 1 for true.
 has case_sensitive => (
     is      => 'ro',
-    isa     => 'Bool',
+    isa     => sub { die "$_[0] is not Bool" unless( ( $_[0] == !!$_[0] ) or ( 0 == $_[0] ) ) },
     default => 1,
 );
 
@@ -67,7 +69,7 @@ sub complete {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Intersection.pm
+++ b/lib/Path/Dispatcher/Rule/Intersection.pm
@@ -1,5 +1,5 @@
 package Path::Dispatcher::Rule::Intersection;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 with 'Path::Dispatcher::Role::Rules';
@@ -19,7 +19,7 @@ sub _match {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Metadata.pm
+++ b/lib/Path/Dispatcher/Rule/Metadata.pm
@@ -1,16 +1,17 @@
 package Path::Dispatcher::Rule::Metadata;
-use Any::Moose;
+use Moo;
+
 extends 'Path::Dispatcher::Rule';
 
 has field => (
     is       => 'ro',
-    isa      => 'Str',
+    isa      => sub { die "$_[0] is not a String" unless( defined $_[0] && '' eq ref $_[0] ) },
     required => 1,
 );
 
 has matcher => (
     is       => 'ro',
-    isa      => 'Path::Dispatcher::Rule',
+    isa      => sub { die "$_[0] not isa Path::Dispatcher::Rule" unless $_[0]->isa('Path::Dispatcher::Rule') },
     required => 1,
 );
 
@@ -29,7 +30,7 @@ sub _match {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Regex.pm
+++ b/lib/Path/Dispatcher/Rule/Regex.pm
@@ -1,10 +1,10 @@
 package Path::Dispatcher::Rule::Regex;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 has regex => (
     is       => 'ro',
-    isa      => 'RegexpRef',
+    isa      => sub { die "not a Regexp" unless 'Regexp' eq ref $_[0] },
     required => 1,
 );
 
@@ -39,7 +39,7 @@ sub _match {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Sequence.pm
+++ b/lib/Path/Dispatcher/Rule/Sequence.pm
@@ -1,12 +1,12 @@
 package Path::Dispatcher::Rule::Sequence;
-use Any::Moose;
+use Moo;
 
 extends 'Path::Dispatcher::Rule';
 with 'Path::Dispatcher::Role::Rules';
 
 has delimiter => (
     is      => 'ro',
-    isa     => 'Str',
+    isa     => sub { die "$_[0] is not a String" unless( defined $_[0] && '' eq ref $_[0] ) },
     default => ' ',
 );
 
@@ -79,7 +79,7 @@ sub untokenize {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Tokens.pm
+++ b/lib/Path/Dispatcher/Rule/Tokens.pm
@@ -1,23 +1,22 @@
 package Path::Dispatcher::Rule::Tokens;
-use Any::Moose;
+use Moo;
 extends 'Path::Dispatcher::Rule';
 
 has tokens => (
     is         => 'ro',
-    isa        => 'ArrayRef',
-    auto_deref => 1,
+    isa        => sub { die "not an ArrayRef" unless 'ARRAY' eq ref $_[0] },
     required   => 1,
 );
 
 has delimiter => (
     is      => 'ro',
-    isa     => 'Str',
+    isa     => sub { die "$_[0] is not a String" unless( defined $_[0] && '' eq ref $_[0] ) },
     default => ' ',
 );
 
 has case_sensitive => (
     is      => 'ro',
-    isa     => 'Bool',
+    isa     => sub { die "$_[0] is not Bool" unless( ( $_[0] == !!$_[0] ) or ( 0 == $_[0] ) ) },
     default => 1,
 );
 
@@ -26,7 +25,7 @@ sub _match_as_far_as_possible {
     my $path = shift;
 
     my @got      = $self->tokenize($path->path);
-    my @expected = $self->tokens;
+    my @expected = @{ $self->tokens };
     my @matched;
 
     while (@got && @expected) {
@@ -139,7 +138,7 @@ sub untokenize {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/lib/Path/Dispatcher/Rule/Under.pm
+++ b/lib/Path/Dispatcher/Rule/Under.pm
@@ -1,18 +1,18 @@
 package Path::Dispatcher::Rule::Under;
-use Any::Moose;
-use Any::Moose '::Util::TypeConstraints';
+use Moo;
 
 extends 'Path::Dispatcher::Rule';
 with 'Path::Dispatcher::Role::Rules';
 
-subtype 'Path::Dispatcher::PrefixRule'
-     => as 'Path::Dispatcher::Rule'
-     => where { $_->prefix }
-     => message { "This rule ($_) does not match just prefixes!" };
-
 has predicate => (
     is  => 'ro',
-    isa => 'Path::Dispatcher::PrefixRule',
+    isa     => sub {
+        die "$_[0] not isa Path::Dispatcher::Rule"
+           unless $_[0]->isa('Path::Dispatcher::Rule');
+
+        die "This rule ($_[0]) does not match just prefixes!"
+            unless $_[0]->prefix;
+    },
 );
 
 sub match {
@@ -71,7 +71,7 @@ sub complete {
 }
 
 __PACKAGE__->meta->make_immutable;
-no Any::Moose;
+no Moo;
 
 1;
 

--- a/t/012-under.t
+++ b/t/012-under.t
@@ -83,7 +83,7 @@ eval {
         ),
     );
 };
-like($@, qr/Attribute \(predicate\) does not pass the type constraint /, "predicate MUST match just a prefix");
+like($@, qr/isa check for "predicate" failed/, "predicate MUST match just a prefix");
 
 done_testing;
 

--- a/t/025-sequence-custom-rule.t
+++ b/t/025-sequence-custom-rule.t
@@ -7,7 +7,7 @@ my @calls;
 
 do {
     package MyApp::Dispatcher::Rule::Language;
-    use Any::Moose;
+    use Moo;
     extends 'Path::Dispatcher::Rule::Enum';
 
     has '+enum' => (

--- a/t/027-custom-named-captures.t
+++ b/t/027-custom-named-captures.t
@@ -5,18 +5,17 @@ use Path::Dispatcher;
 
 {
     package My::Rule::NamedEnum;
-    use Any::Moose;
+    use Moo;
     extends 'Path::Dispatcher::Rule';
 
     has name => (
         is       => 'ro',
-        isa      => 'Str',
         required => 1,
     );
 
     has regex => (
         is       => 'ro',
-        isa      => 'RegexpRef',
+        isa      => sub{ die "not a regex" unless 'Regexp' eq ref $_[0] },
         required => 1,
     );
 


### PR DESCRIPTION
Switch the Dist from Any::Moose to Moo.

In most cases this has been done via a simply replacing one with the other at the top and bottom of each source file and writing a few anonymous subs for isa tests.

This passes all the unit tests in the dist, I have also tested the new version against the 5 downstream reverse dependencies of the module using Test::DependentModules.

Of those 5 modules, three fail their tests anyway, one was trivially fixable, the other two not. Using this new version the three good good modules passed with this latest changeset. The two bad ones failed in the same places as before.

After these tests, and the module's own unit tests I am now fairly confident that this change is safe. It could of course break a DarkPan dependency, but we cannot test for that.
